### PR TITLE
feature: Add `musicbrainzid` as parameter alias

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,8 +207,14 @@ function checkLogin() {
 }
 
 function checkMbid(params) {
+  // Check for the "mbid" parameter
   mbid = params.get("mbid");
   mbidInvalid = true;
+
+  if (!mbid || mbid == "") {
+    // "mbid" isn't found. Let's check for the alias
+    mbid = params.get("musicbrainzid");
+  }
 
   if (!mbid || mbid == "") {
     mbid = null;


### PR DESCRIPTION
Currently, the website looks for the parameter `mbid` in the URL. However, `mbid` often is associated with tracking and on browsers with any decent tracking protection (like Firefox and Librewolf, or extensions), this parameter get removed from the url.

So I added a alias that doesn't get flagged as tracking, and kept the old one as well for backward compatibility